### PR TITLE
fix: Extend props with props of the time component

### DIFF
--- a/demo/timeagoComponent.tsx
+++ b/demo/timeagoComponent.tsx
@@ -93,6 +93,22 @@ export default class TimeagoComponent extends React.Component {
             </pre>
           </div>
         </div>
+
+        <div className="examples">
+          <div className="parent">
+            <label>
+              6. The result is rendered as a `&lt;time&gt;` element. All attributes you can pass to `&lt;time&gt;` you
+              can also pass to `&lt;TimeAgo&gt;`:
+            </label>
+            <strong>
+              <TimeAgo datetime={'2019-11-15'} id="timeago" title="Nov 15, 2019" />
+            </strong>
+            <pre>
+              <code>{"<TimeAgo datetime={'2019-11-15'} id='timeago' title='Nov 15, 2019' />\n"}</code>
+            </pre>
+          </div>
+        </div>
+
         <h3>
           Download / Document on GitHub! <a href="https://github.com/hustcc/timeago-react">timeago-react</a>
         </h3>

--- a/src/timeago-react.tsx
+++ b/src/timeago-react.tsx
@@ -36,8 +36,6 @@ export interface TimeAgoProps extends React.ComponentProps<'time'> {
   readonly live?: boolean; // real time render.
   readonly opts?: Opts;
   readonly locale?: string; // locale lang
-  readonly className?: string; // class name
-  readonly style?: React.CSSProperties; // style object
 }
 
 export default class TimeAgo extends React.Component<TimeAgoProps> {

--- a/src/timeago-react.tsx
+++ b/src/timeago-react.tsx
@@ -31,7 +31,7 @@ const toDateTime = (input: TDate): string => {
   return '' + (input instanceof Date ? input.getTime() : input);
 };
 
-export interface TimeAgoProps {
+export interface TimeAgoProps extends React.ComponentProps<'time'> {
   readonly datetime: TDate; // date to be formatted
   readonly live?: boolean; // real time render.
   readonly opts?: Opts;


### PR DESCRIPTION
The TimeAgo component already accepts additional arguments which are passed to the time component. However `TimeAgoProps` needs to extend from these props. Otherwise we would get a compiler error in typescript when we use them.

I came across when I wanted to set the `title` of the created `<time>` element. This is common to show the actual date of the event. Here an example from Github:

![bild](https://user-images.githubusercontent.com/1327215/114924505-5ebc1200-9e2e-11eb-8e5a-25206d7120a6.png)

However without this PR I get a `No overload matches this call` error when I set the `title` attribute.



