### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The LTS node version which is currently active is 14.x so I guess this should be added (see https://nodejs.org/en/about/releases/ ). 8.x is not in maintenance any more and thus can be deleted.

*Note:* The "end-of-life" for 10.x will be soon, so this might be deleted as well. Also 16.x can be added, since the initial release will start in less than a week. 