### PR TITLE
fix: redundant update

### DIFF
--- a/src/timeago-react.tsx
+++ b/src/timeago-react.tsx
@@ -38,7 +38,7 @@ export interface TimeAgoProps extends React.ComponentProps<'time'> {
   readonly locale?: string; // locale lang
 }
 
-export default class TimeAgo extends React.Component<TimeAgoProps> {
+export default class TimeAgo extends React.PureComponent<TimeAgoProps> {
   static defaultProps = {
     live: true,
     className: '',


### PR DESCRIPTION
to fix #40 

## Root Cause 

Whenever parent components updates, `<TimeAgo>` would update as well

## Solution

Use PureComponent instead